### PR TITLE
Fix ParamRef recognition for CAST functions in the MySQL engine

### DIFF
--- a/internal/engine/dolphin/convert.go
+++ b/internal/engine/dolphin/convert.go
@@ -873,7 +873,10 @@ func (c *cc) convertFrameClause(n *pcast.FrameClause) ast.Node {
 }
 
 func (c *cc) convertFuncCastExpr(n *pcast.FuncCastExpr) ast.Node {
-	return todo(n)
+	return &ast.TypeCast{
+		Arg:      c.convert(n.Expr),
+		TypeName: &ast.TypeName{Name: types.TypeStr(n.Tp.Tp)},
+	}
 }
 
 func (c *cc) convertGetFormatSelectorExpr(n *pcast.GetFormatSelectorExpr) ast.Node {

--- a/internal/engine/dolphin/convert.go
+++ b/internal/engine/dolphin/convert.go
@@ -1117,7 +1117,13 @@ func (c *cc) convertRollbackStmt(n *pcast.RollbackStmt) ast.Node {
 }
 
 func (c *cc) convertRowExpr(n *pcast.RowExpr) ast.Node {
-	return todo(n)
+	var items []ast.Node
+	for _, v := range n.Values {
+		items = append(items, c.convert(v))
+	}
+	return &ast.RowExpr{
+		Args: &ast.List{Items: items},
+	}
 }
 
 func (c *cc) convertSetCollationExpr(n *pcast.SetCollationExpr) ast.Node {

--- a/internal/engine/dolphin/convert_test.go
+++ b/internal/engine/dolphin/convert_test.go
@@ -31,25 +31,22 @@ func Test_ParamRefParsing(t *testing.T) {
 			if l := len(stmts); l != 1 {
 				t.Fatalf("expected 1 statement, got %d", l)
 			}
-			e := &refExtractor{}
-			astutils.Walk(e, stmts[0].Raw.Stmt)
-			if got, want := len(e.params), test.paramRefCount; got != want {
+			paramRefs := extractParamRefs(stmts[0].Raw.Stmt)
+			if got, want := len(paramRefs), test.paramRefCount; got != want {
 				t.Fatalf("extracted params: want %d, got %d", want, got)
 			}
 		})
 	}
 }
 
-// refExtractor is an astutils.Visitor instance that will extract all of the
-// ParamRef instances it encounters while walking an AST.
-type refExtractor struct {
-	params []*ast.ParamRef
-}
-
-func (e *refExtractor) Visit(n ast.Node) astutils.Visitor {
-	switch t := n.(type) {
-	case *ast.ParamRef:
-		e.params = append(e.params, t)
-	}
-	return e
+// extractParamRefs extracts all of the ParamRef instances by walking the provided AST.
+func extractParamRefs(n ast.Node) []*ast.ParamRef {
+	var params []*ast.ParamRef
+	astutils.Walk(astutils.VisitorFunc(func(n ast.Node) {
+		switch t := n.(type) {
+		case *ast.ParamRef:
+			params = append(params, t)
+		}
+	}), n)
+	return params
 }

--- a/internal/engine/dolphin/convert_test.go
+++ b/internal/engine/dolphin/convert_test.go
@@ -17,6 +17,8 @@ func Test_ParamRefParsing(t *testing.T) {
 	}{
 		{name: "tuple comparison", paramRefCount: 2, input: "SELECT * WHERE (a, b) > (?, ?)"},
 		{name: "cast", paramRefCount: 1, input: "SELECT CAST(? AS JSON)"},
+		{name: "convert", paramRefCount: 1, input: "SELECT CONVERT(? USING UTF8)"},
+		{name: "issues/1622", paramRefCount: 1, input: "INSERT INTO foo (x) VALUES (CAST(CONVERT(? USING UTF8) AS JSON))"},
 	}
 	for _, test := range cases {
 		test := test

--- a/internal/engine/dolphin/convert_test.go
+++ b/internal/engine/dolphin/convert_test.go
@@ -1,0 +1,42 @@
+package dolphin_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/kyleconroy/sqlc/internal/engine/dolphin"
+	"github.com/kyleconroy/sqlc/internal/sql/ast"
+	"github.com/kyleconroy/sqlc/internal/sql/astutils"
+)
+
+func Test_TupleComparison(t *testing.T) {
+	p := dolphin.NewParser()
+	stmts, err := p.Parse(strings.NewReader("SELECT * WHERE (a, b) > (?, ?)"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if l := len(stmts); l != 1 {
+		t.Fatalf("expected 1 statement, got %d", l)
+	}
+
+	// Right now all this test does is make sure we noticed the two ParamRefs.
+	// This ensures that the Go code is generated correctly.
+	e := &refExtractor{}
+	astutils.Walk(e, stmts[0].Raw.Stmt)
+	if l := len(e.params); l != 2 {
+		t.Fatalf("expected to extract 2 params, got %d", l)
+	}
+}
+
+type refExtractor struct {
+	params []*ast.ParamRef
+}
+
+func (e *refExtractor) Visit(n ast.Node) astutils.Visitor {
+	switch t := n.(type) {
+	case *ast.ParamRef:
+		e.params = append(e.params, t)
+	}
+	return e
+}

--- a/internal/engine/dolphin/convert_test.go
+++ b/internal/engine/dolphin/convert_test.go
@@ -29,6 +29,8 @@ func Test_TupleComparison(t *testing.T) {
 	}
 }
 
+// refExtractor is an astutils.Visitor instance that will extract all of the
+// ParamRef instances it encounters while walking an AST.
 type refExtractor struct {
 	params []*ast.ParamRef
 }


### PR DESCRIPTION
This builds on top of https://github.com/kyleconroy/sqlc/pull/1649, and I've intentionally opened this PR on top of that one.

Fixes https://github.com/kyleconroy/sqlc/issues/1622